### PR TITLE
feat: generate python lockfile

### DIFF
--- a/blueprints/devops/package.json
+++ b/blueprints/devops/package.json
@@ -53,7 +53,7 @@
   },
   "main": "lib/index.js",
   "license": "MIT",
-  "version": "0.0.11",
+  "version": "0.0.20",
   "types": "lib/index.d.ts",
   "publishingSpace": "Centre-of-Prototyping-Excellence",
   "displayName": "PDK - DevOps",

--- a/packages/pdk-synth/src/pdk-synth.ts
+++ b/packages/pdk-synth/src/pdk-synth.ts
@@ -317,7 +317,7 @@ export class PDKSynth extends Component {
   }
 
   private renderPythonLockfileCommand(): string {
-    return 'curl -sSL https://install.python-poetry.org | python3 - && npm install -g @aws/pdk && pdk install';
+    return 'npm install yarn --no-save && curl -sSL https://install.python-poetry.org | LD_LIBRARY_PATH="" python3 && PATH=$PATH:$HOME/.local/bin LD_LIBRARY_PATH="" npx projen install';
   }
 
   private getModelLanguage(options: ApiOptions): ModelLanguage {


### PR DESCRIPTION
- Generate poetry lockfiles once a DevOps blueprint exists.

Note: This has not been fully tested as the synth worker image has Python 3.9 installed, however Python 3.11 is required.